### PR TITLE
alternative to plotcorr using geom_tile

### DIFF
--- a/script.R
+++ b/script.R
@@ -1,17 +1,32 @@
-setwd("D:/R/MirMet//Dendrogram")
 library("tidyr")
 library("dplyr")
 library("ggplot2")
 library("ggdendro")
 library("magrittr")
-
+library("RColorBrewer")
 
 tab <- read.table("PhysioParam00.txt", header = TRUE, sep = "\t")
 tab_comp <- tab %>% select(NodeID1 = NodeID2, NodeID2 = NodeID1, CE)
 tab %<>% bind_rows(tab_comp)
 
+
+
+
 physioa<-as.matrix(spread(tab, NodeID2, CE))
 physioa[is.na(physioa)] <- 1
+
+# heatmap
+gather(as.data.frame(physioa), "N", "CE", 2:ncol(physioa))
+cols <- brewer.pal(7,"YlOrRd")
+h <- ggplot(gather(as.data.frame(physioa), "NodeID2", "CE", 2:ncol(physioa)))+
+  geom_tile(aes(x = NodeID1, y = NodeID2, fill = as.numeric(CE)))+
+  theme_classic(16)+
+  theme(axis.text.x = element_text(angle = 90, hjust = 1))+
+  scale_fill_gradient(expression(R**2), low = cols[1], high = cols[7])+
+  xlab("")+
+  ylab("")
+plot(h)
+
 
 group <- read.table("Groups.txt", header = TRUE, sep="\t")
 physioa2 <- left_join(as.data.frame(physioa), group, by=c("NodeID1" = "NodeID"))


### PR DESCRIPTION
by using the melted tab after setting the correlation to 1 for identical pairs. The scale_fill_gradient could be set to the limits = c(0, 1) to set the minimum to zero instead of min(tab$CE)

resulting plot is:

![rplot](https://cloud.githubusercontent.com/assets/710181/6865622/d4c1e220-d46f-11e4-94e7-211f8ab8be90.png)



